### PR TITLE
STEP08

### DIFF
--- a/src/main/java/com/chaw/concert/app/domain/concert/query/entity/Concert.java
+++ b/src/main/java/com/chaw/concert/app/domain/concert/query/entity/Concert.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/com/chaw/concert/app/domain/concert/query/entity/ConcertSchedule.java
+++ b/src/main/java/com/chaw/concert/app/domain/concert/query/entity/ConcertSchedule.java
@@ -20,8 +20,8 @@ public class ConcertSchedule {
     @Column(name = "concert_id")
     private Long concertId; // 공연ID
 
-    @Column(name = "is_sold")
-    private Boolean isSold; // 판매 여부
+    @Column(name = "is_sold_out")
+    private Boolean isSoldOut; // 판매 여부
 
     @Column(name = "total_seat")
     private Integer totalSeat; // 총 좌석 수

--- a/src/main/java/com/chaw/concert/app/domain/concert/query/repository/ConcertScheduleRepository.java
+++ b/src/main/java/com/chaw/concert/app/domain/concert/query/repository/ConcertScheduleRepository.java
@@ -5,13 +5,15 @@ import com.chaw.concert.app.domain.concert.query.entity.ConcertSchedule;
 import java.util.List;
 
 public interface ConcertScheduleRepository {
-    List<ConcertSchedule> findByConcertIdAndIsSold(Long concertId, boolean isSold);
-
-    ConcertSchedule save(ConcertSchedule concertSchedule);
+    List<ConcertSchedule> findByConcertIdAndIsSoldOut(Long concertId, boolean isSoldOut);
 
     ConcertSchedule findById(Long id);
 
     ConcertSchedule findByIdWithLock(Long id);
+
+    ConcertSchedule save(ConcertSchedule concertSchedule);
+
+    boolean decreaseAvailableSeat(Long concertScheduleId);
 
     void deleteAll();
 }

--- a/src/main/java/com/chaw/concert/app/domain/concert/query/usecase/GetConcertSchedulesNotSoldOut.java
+++ b/src/main/java/com/chaw/concert/app/domain/concert/query/usecase/GetConcertSchedulesNotSoldOut.java
@@ -27,7 +27,7 @@ public class GetConcertSchedulesNotSoldOut {
             throw new ConcertNotFoundException();
         }
 
-        List<ConcertSchedule> concertSchedules = concertScheduleRepository.findByConcertIdAndIsSold(input.concertId(), false);
+        List<ConcertSchedule> concertSchedules = concertScheduleRepository.findByConcertIdAndIsSoldOut(input.concertId(), false);
 
         return new Output(
                 concert.getId(),
@@ -37,7 +37,7 @@ public class GetConcertSchedulesNotSoldOut {
                 concert.getHost(),
                 concertSchedules.stream().map(schedule -> new Output.Item(
                         schedule.getId(),
-                        schedule.getIsSold(),
+                        schedule.getIsSoldOut(),
                         schedule.getTotalSeat(),
                         schedule.getAvailableSeat(),
                         schedule.getDateConcert()
@@ -59,7 +59,7 @@ public class GetConcertSchedulesNotSoldOut {
     ) {
         public record Item (
                 Long id,
-                Boolean isSold,
+                Boolean isSoldOut,
                 Integer totalSeat,
                 Integer availableSeat,
                 LocalDateTime dateConcert

--- a/src/main/java/com/chaw/concert/app/domain/concert/reserve/exception/AvailableSeatNotExistException.java
+++ b/src/main/java/com/chaw/concert/app/domain/concert/reserve/exception/AvailableSeatNotExistException.java
@@ -1,0 +1,11 @@
+package com.chaw.concert.app.domain.concert.reserve.exception;
+
+public class AvailableSeatNotExistException extends IllegalArgumentException {
+
+    public static final String DEFAULT_MESSAGE = "남은 좌석이 없습니다.";
+
+    public AvailableSeatNotExistException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+}

--- a/src/main/java/com/chaw/concert/app/domain/concert/reserve/exception/IllegalConcertAndScheduleException.java
+++ b/src/main/java/com/chaw/concert/app/domain/concert/reserve/exception/IllegalConcertAndScheduleException.java
@@ -1,0 +1,11 @@
+package com.chaw.concert.app.domain.concert.reserve.exception;
+
+public class IllegalConcertAndScheduleException extends IllegalArgumentException {
+
+    public static final String DEFAULT_MESSAGE = "콘서트와 공연일정이 일치하지 않습니다.";
+
+    public IllegalConcertAndScheduleException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+}

--- a/src/main/java/com/chaw/concert/app/domain/concert/reserve/exception/IllegalScheduleAndTicketException.java
+++ b/src/main/java/com/chaw/concert/app/domain/concert/reserve/exception/IllegalScheduleAndTicketException.java
@@ -1,0 +1,11 @@
+package com.chaw.concert.app.domain.concert.reserve.exception;
+
+public class IllegalScheduleAndTicketException extends IllegalArgumentException {
+
+    public static final String DEFAULT_MESSAGE = "공연일정과 티켓이 일치하지 않습니다.";
+
+    public IllegalScheduleAndTicketException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+}

--- a/src/main/java/com/chaw/concert/app/domain/concert/reserve/usecase/PayTicket.java
+++ b/src/main/java/com/chaw/concert/app/domain/concert/reserve/usecase/PayTicket.java
@@ -16,6 +16,7 @@ import com.chaw.concert.app.domain.concert.reserve.entity.Payment;
 import com.chaw.concert.app.domain.concert.reserve.entity.PaymentMethod;
 import com.chaw.concert.app.domain.concert.reserve.entity.Reserve;
 import com.chaw.concert.app.domain.concert.reserve.entity.ReserveStatus;
+import com.chaw.concert.app.domain.concert.reserve.exception.AvailableSeatNotExistException;
 import com.chaw.concert.app.domain.concert.reserve.exception.ExpiredReserveException;
 import com.chaw.concert.app.domain.concert.reserve.repository.PaymentRepository;
 import com.chaw.concert.app.domain.concert.reserve.repository.ReserveRepository;
@@ -67,11 +68,10 @@ public class PayTicket {
 
         LocalDateTime now = LocalDateTime.now();
         // (예약가능 좌석수, 재고없음) 업데이트
-        concertSchedule.setAvailableSeat(concertSchedule.getAvailableSeat() - 1);
-        if (concertSchedule.getAvailableSeat() == 0) {
-            concertSchedule.setIsSold(true);
+        boolean result = concertScheduleRepository.decreaseAvailableSeat(concertSchedule.getId());
+        if (!result) {
+            throw new AvailableSeatNotExistException();
         }
-        concertScheduleRepository.save(concertSchedule);
 
         // 티켓 상태 업데이트
         ticket.setStatus(TicketStatus.PAID);

--- a/src/main/java/com/chaw/concert/app/domain/concert/reserve/usecase/PayTicket.java
+++ b/src/main/java/com/chaw/concert/app/domain/concert/reserve/usecase/PayTicket.java
@@ -11,9 +11,6 @@ import com.chaw.concert.app.domain.concert.query.entity.Concert;
 import com.chaw.concert.app.domain.concert.query.entity.ConcertSchedule;
 import com.chaw.concert.app.domain.concert.query.entity.Ticket;
 import com.chaw.concert.app.domain.concert.query.entity.TicketStatus;
-import com.chaw.concert.app.domain.concert.query.exception.ConcertNotFoundException;
-import com.chaw.concert.app.domain.concert.query.exception.ConcertScheduleNotFoundException;
-import com.chaw.concert.app.domain.concert.query.exception.TicketNotFoundException;
 import com.chaw.concert.app.domain.concert.query.repository.ConcertRepository;
 import com.chaw.concert.app.domain.concert.query.repository.ConcertScheduleRepository;
 import com.chaw.concert.app.domain.concert.query.repository.TicketRepository;
@@ -27,6 +24,7 @@ import com.chaw.concert.app.domain.concert.reserve.entity.ReserveStatus;
 import com.chaw.concert.app.domain.concert.reserve.exception.*;
 import com.chaw.concert.app.domain.concert.reserve.repository.PaymentRepository;
 import com.chaw.concert.app.domain.concert.reserve.repository.ReserveRepository;
+import com.chaw.concert.app.domain.concert.reserve.validation.ReserveValidation;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,8 +45,9 @@ public class PayTicket {
     private final TicketRepository ticketRepository;
     private final ReserveRepository reserveRepository;
     private final PaymentRepository paymentRepository;
+    private final ReserveValidation reserveValidation;
 
-    public PayTicket(ConcertRepository concertRepository, WaitQueueRepository waitQueueRepository, PointRepository pointRepository, PointHistoryRepository pointHistoryRepository, ConcertScheduleRepository concertScheduleRepository, TicketRepository ticketRepository, ReserveRepository reserveRepository, PaymentRepository paymentRepository) {
+    public PayTicket(ConcertRepository concertRepository, WaitQueueRepository waitQueueRepository, PointRepository pointRepository, PointHistoryRepository pointHistoryRepository, ConcertScheduleRepository concertScheduleRepository, TicketRepository ticketRepository, ReserveRepository reserveRepository, PaymentRepository paymentRepository, ReserveValidation reserveValidation) {
         this.concertRepository = concertRepository;
         this.waitQueueRepository = waitQueueRepository;
         this.pointRepository = pointRepository;
@@ -57,6 +56,7 @@ public class PayTicket {
         this.ticketRepository = ticketRepository;
         this.reserveRepository = reserveRepository;
         this.paymentRepository = paymentRepository;
+        this.reserveValidation = reserveValidation;
     }
 
     @Transactional
@@ -68,10 +68,12 @@ public class PayTicket {
         Reserve reserve = reserveRepository.findByUserIdAndTicketIdOrderByIdDescLimit(input.userId(), input.ticketId(), 1);
         WaitQueue waitQueue = waitQueueRepository.findByUserId(input.userId());
 
-        validate(point, concert, concertSchedule, ticket, reserve, waitQueue);
+        reserveValidation.validateConcertDetails(concert, concertSchedule, ticket);
+        reserveValidation.validatePayTicketDetails(waitQueue, point, reserve, ticket);
+
+        handleExpiredReserve(ticket, reserve, waitQueue);
 
         LocalDateTime now = LocalDateTime.now();
-
         // (예약가능 좌석수, 재고없음) 업데이트
         concertSchedule.setAvailableSeat(concertSchedule.getAvailableSeat() - 1);
         if (concertSchedule.getAvailableSeat() == 0) {
@@ -119,53 +121,9 @@ public class PayTicket {
         return new Output(true, payment.getId(), point.getBalance());
     }
 
-    /**
-     * 공통: not null
-     * point 잔액
-     * ticket 예약 상태
-     * reserve 예약 상태, 예약제한시간
-     */
-    public void validate(Point point, Concert concert, ConcertSchedule concertSchedule, Ticket ticket, Reserve reserve, WaitQueue waitQueue) {
-        if (point == null) {
-            throw new PointNotFoundException();
-        }
-        if (concert == null) {
-            throw new ConcertNotFoundException();
-        }
-        if (concertSchedule == null) {
-            throw new ConcertScheduleNotFoundException();
-        }
-        if (ticket == null) {
-            throw new TicketNotFoundException();
-        }
-        if (reserve == null) {
-            throw new ReserveNotFoundException();
-        }
-        if (waitQueue == null) {
-            throw new WaitQueueNotFoundException();
-        }
-
+    // 예약제한시간 체크
+    public void handleExpiredReserve(Ticket ticket, Reserve reserve, WaitQueue waitQueue) {
         LocalDateTime now = LocalDateTime.now();
-
-        // 잔액 체크
-        if (point.getBalance() < reserve.getAmount()) {
-            throw new NotEnoughBalanceException();
-        }
-
-        // 티켓 예약 상태 체크
-        if (ticket.getStatus() != TicketStatus.RESERVE) {
-            throw new TicketNotInStatusReserveException();
-        }
-
-        // 예약 상태 체크
-        if (reserve.getReserveStatus() == ReserveStatus.PAID) {
-            throw new AlreadyPaidReserveException();
-        }
-        else if (reserve.getReserveStatus() == ReserveStatus.CANCEL) {
-            throw new CanceledReserveException();
-        }
-
-        // 예약제한시간 체크
         if (now.isAfter(reserve.getCreatedAt().plusMinutes(EXPIRED_MINUTES))) {
             ticket.setStatus(TicketStatus.EMPTY);
             ticket.setReserveUserId(null);

--- a/src/main/java/com/chaw/concert/app/domain/concert/reserve/validation/ReserveValidation.java
+++ b/src/main/java/com/chaw/concert/app/domain/concert/reserve/validation/ReserveValidation.java
@@ -11,8 +11,6 @@ import com.chaw.concert.app.domain.concert.query.exception.ConcertNotFoundExcept
 import com.chaw.concert.app.domain.concert.query.exception.ConcertScheduleNotFoundException;
 import com.chaw.concert.app.domain.concert.query.exception.TicketAlreadyReservedException;
 import com.chaw.concert.app.domain.concert.query.exception.TicketNotFoundException;
-import com.chaw.concert.app.domain.concert.queue.entity.WaitQueue;
-import com.chaw.concert.app.domain.concert.queue.exception.WaitQueueNotFoundException;
 import com.chaw.concert.app.domain.concert.reserve.entity.Reserve;
 import com.chaw.concert.app.domain.concert.reserve.entity.ReserveStatus;
 import com.chaw.concert.app.domain.concert.reserve.exception.*;
@@ -51,10 +49,7 @@ public class ReserveValidation {
      * ticket 예약 상태
      * reserve 예약 상태, 예약제한시간
      */
-    public void validatePayTicketDetails(WaitQueue waitQueue, Point point, Reserve reserve, Ticket ticket) {
-        if (waitQueue == null) {
-            throw new WaitQueueNotFoundException();
-        }
+    public void validatePayTicketDetails(Point point, Reserve reserve, Ticket ticket) {
         if (point == null) {
             throw new PointNotFoundException();
         }

--- a/src/main/java/com/chaw/concert/app/domain/concert/reserve/validation/ReserveValidation.java
+++ b/src/main/java/com/chaw/concert/app/domain/concert/reserve/validation/ReserveValidation.java
@@ -1,0 +1,83 @@
+package com.chaw.concert.app.domain.concert.reserve.validation;
+
+import com.chaw.concert.app.domain.common.user.entity.Point;
+import com.chaw.concert.app.domain.common.user.exception.NotEnoughBalanceException;
+import com.chaw.concert.app.domain.common.user.exception.PointNotFoundException;
+import com.chaw.concert.app.domain.concert.query.entity.Concert;
+import com.chaw.concert.app.domain.concert.query.entity.ConcertSchedule;
+import com.chaw.concert.app.domain.concert.query.entity.Ticket;
+import com.chaw.concert.app.domain.concert.query.entity.TicketStatus;
+import com.chaw.concert.app.domain.concert.query.exception.ConcertNotFoundException;
+import com.chaw.concert.app.domain.concert.query.exception.ConcertScheduleNotFoundException;
+import com.chaw.concert.app.domain.concert.query.exception.TicketAlreadyReservedException;
+import com.chaw.concert.app.domain.concert.query.exception.TicketNotFoundException;
+import com.chaw.concert.app.domain.concert.queue.entity.WaitQueue;
+import com.chaw.concert.app.domain.concert.queue.exception.WaitQueueNotFoundException;
+import com.chaw.concert.app.domain.concert.reserve.entity.Reserve;
+import com.chaw.concert.app.domain.concert.reserve.entity.ReserveStatus;
+import com.chaw.concert.app.domain.concert.reserve.exception.*;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReserveValidation {
+
+    public void validateConcertDetails(Concert concert, ConcertSchedule concertSchedule, Ticket ticket) {
+        if (concert == null) {
+            throw new ConcertNotFoundException();
+        }
+        if (concertSchedule == null) {
+            throw new ConcertScheduleNotFoundException();
+        }
+        if (ticket == null) {
+            throw new TicketNotFoundException();
+        }
+
+        if (!concert.getId().equals(concertSchedule.getConcertId())) {
+            throw new IllegalConcertAndScheduleException();
+        }
+        if (!concertSchedule.getId().equals(ticket.getConcertScheduleId())) {
+            throw new IllegalScheduleAndTicketException();
+        }
+    }
+
+    public void validateReserveDetails(Ticket ticket) {
+        if (!ticket.getStatus().equals(TicketStatus.EMPTY)) {
+            throw new TicketAlreadyReservedException();
+        }
+    }
+
+    /**
+     * point 잔액
+     * ticket 예약 상태
+     * reserve 예약 상태, 예약제한시간
+     */
+    public void validatePayTicketDetails(WaitQueue waitQueue, Point point, Reserve reserve, Ticket ticket) {
+        if (waitQueue == null) {
+            throw new WaitQueueNotFoundException();
+        }
+        if (point == null) {
+            throw new PointNotFoundException();
+        }
+        if (reserve == null) {
+            throw new ReserveNotFoundException();
+        }
+
+        // 잔액 체크
+        if (point.getBalance() < reserve.getAmount()) {
+            throw new NotEnoughBalanceException();
+        }
+
+        // 티켓 예약 상태 체크
+        if (ticket.getStatus() != TicketStatus.RESERVE) {
+            throw new TicketNotInStatusReserveException();
+        }
+
+        // 예약 상태 체크
+        if (reserve.getReserveStatus() == ReserveStatus.PAID) {
+            throw new AlreadyPaidReserveException();
+        }
+        else if (reserve.getReserveStatus() == ReserveStatus.CANCEL) {
+            throw new CanceledReserveException();
+        }
+    }
+}

--- a/src/main/java/com/chaw/concert/app/infrastructure/mysql/conert/query/ConcertScheduleJpaRepository.java
+++ b/src/main/java/com/chaw/concert/app/infrastructure/mysql/conert/query/ConcertScheduleJpaRepository.java
@@ -4,6 +4,7 @@ import com.chaw.concert.app.domain.concert.query.entity.ConcertSchedule;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -11,9 +12,17 @@ import java.util.List;
 
 @Repository
 public interface ConcertScheduleJpaRepository extends JpaRepository<ConcertSchedule, Long> {
-    List<ConcertSchedule> findByConcertIdAndIsSold(Long concertId, boolean isSold);
+    List<ConcertSchedule> findByConcertIdAndIsSoldOut(Long concertId, boolean isSoldOut);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT cs FROM ConcertSchedule cs WHERE cs.id = :id")
     ConcertSchedule findByIdWithLock(Long id);
+
+    @Modifying
+    @Query("" +
+            "UPDATE ConcertSchedule cs " +
+            "SET cs.availableSeat = cs.availableSeat - 1, " +
+            "    cs.isSoldOut = CASE WHEN cs.availableSeat = 0 THEN true ELSE false END " +
+            "WHERE cs.id = :concertScheduleId AND cs.availableSeat > 0")
+    int decreaseAvailableSeat(Long concertScheduleId);
 }

--- a/src/main/java/com/chaw/concert/app/infrastructure/mysql/conert/query/ConcertScheduleRepositoryImpl.java
+++ b/src/main/java/com/chaw/concert/app/infrastructure/mysql/conert/query/ConcertScheduleRepositoryImpl.java
@@ -15,13 +15,18 @@ public class ConcertScheduleRepositoryImpl implements ConcertScheduleRepository 
     }
 
     @Override
-    public List<ConcertSchedule> findByConcertIdAndIsSold(Long concertId, boolean isSold) {
-        return repository.findByConcertIdAndIsSold(concertId, isSold);
+    public List<ConcertSchedule> findByConcertIdAndIsSoldOut(Long concertId, boolean isSoldOut) {
+        return repository.findByConcertIdAndIsSoldOut(concertId, isSoldOut);
     }
 
     @Override
     public ConcertSchedule save(ConcertSchedule concertSchedule) {
         return repository.save(concertSchedule);
+    }
+
+    @Override
+    public boolean decreaseAvailableSeat(Long concertScheduleId) {
+        return repository.decreaseAvailableSeat(concertScheduleId) > 0;
     }
 
     @Override

--- a/src/main/java/com/chaw/concert/app/infrastructure/mysql/conert/query/TicketJpaRepository.java
+++ b/src/main/java/com/chaw/concert/app/infrastructure/mysql/conert/query/TicketJpaRepository.java
@@ -8,9 +8,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface TicketJpaRepository extends JpaRepository<Ticket, Long> {

--- a/src/test/java/com/chaw/app/domain/concert/e2e/ConcertE2E.java
+++ b/src/test/java/com/chaw/app/domain/concert/e2e/ConcertE2E.java
@@ -231,7 +231,7 @@ public class ConcertE2E {
     }
 
     @Test
-    @Disabled // 테스트 데이터 만들기용
+    @Disabled // 테스트 데이터 만들기
     void testForData() {
         // do nothing
     }

--- a/src/test/java/com/chaw/app/domain/concert/e2e/ConcertE2E.java
+++ b/src/test/java/com/chaw/app/domain/concert/e2e/ConcertE2E.java
@@ -101,7 +101,7 @@ public class ConcertE2E {
 
         ConcertSchedule concertSchedule = ConcertSchedule.builder()
                 .concertId(concert.getId())
-                .isSold(false)
+                .isSoldOut(false)
                 .totalSeat(50)
                 .availableSeat(50)
                 .dateConcert(LocalDateTime.now().plusDays(1))

--- a/src/test/java/com/chaw/app/domain/concert/query/usecase/GetConcertSchedulesNotSoldOutIT.java
+++ b/src/test/java/com/chaw/app/domain/concert/query/usecase/GetConcertSchedulesNotSoldOutIT.java
@@ -47,7 +47,7 @@ public class GetConcertSchedulesNotSoldOutIT {
 
         ConcertSchedule schedule1 = ConcertSchedule.builder()
                 .concertId(concert.getId())
-                .isSold(false)  // 판매 중
+                .isSoldOut(false)  // 판매 중
                 .totalSeat(100)
                 .availableSeat(50)
                 .dateConcert(LocalDateTime.now().plusDays(1))
@@ -56,7 +56,7 @@ public class GetConcertSchedulesNotSoldOutIT {
 
         ConcertSchedule schedule2 = ConcertSchedule.builder()
                 .concertId(concert.getId())
-                .isSold(true)  // 판매 완료
+                .isSoldOut(true)  // 판매 완료
                 .totalSeat(100)
                 .availableSeat(0)
                 .dateConcert(LocalDateTime.now().plusDays(2))
@@ -84,7 +84,7 @@ public class GetConcertSchedulesNotSoldOutIT {
         assertNotNull(concertSchedules);
         assertEquals(1, concertSchedules.size());
         GetConcertSchedulesNotSoldOut.Output.Item schedule = concertSchedules.get(0);
-        assertEquals(false, schedule.isSold());
+        assertEquals(false, schedule.isSoldOut());
         assertEquals(100, schedule.totalSeat());
         assertEquals(50, schedule.availableSeat());
     }

--- a/src/test/java/com/chaw/app/domain/concert/query/usecase/GetConcertSchedulesNotSoldOutUnitTest.java
+++ b/src/test/java/com/chaw/app/domain/concert/query/usecase/GetConcertSchedulesNotSoldOutUnitTest.java
@@ -46,7 +46,7 @@ public class GetConcertSchedulesNotSoldOutUnitTest {
         assertThrows(ConcertNotFoundException.class, () -> getConcertSchedulesNotSoldOut.execute(input));
 
         verify(concertRepository, times(1)).findById(concertId);
-        verify(concertScheduleRepository, never()).findByConcertIdAndIsSold(anyLong(), anyBoolean());
+        verify(concertScheduleRepository, never()).findByConcertIdAndIsSoldOut(anyLong(), anyBoolean());
     }
 
     @Test
@@ -67,7 +67,7 @@ public class GetConcertSchedulesNotSoldOutUnitTest {
                 ConcertSchedule.builder()
                         .id(1L)
                         .concertId(concertId)
-                        .isSold(false)
+                        .isSoldOut(false)
                         .totalSeat(100)
                         .availableSeat(50)
                         .dateConcert(LocalDateTime.now().plusDays(1))
@@ -75,14 +75,14 @@ public class GetConcertSchedulesNotSoldOutUnitTest {
                 ConcertSchedule.builder()
                         .id(2L)
                         .concertId(concertId)
-                        .isSold(false)
+                        .isSoldOut(false)
                         .totalSeat(200)
                         .availableSeat(100)
                         .dateConcert(LocalDateTime.now().plusDays(2))
                         .build()
         );
 
-        when(concertScheduleRepository.findByConcertIdAndIsSold(concertId, false)).thenReturn(concertSchedules);
+        when(concertScheduleRepository.findByConcertIdAndIsSoldOut(concertId, false)).thenReturn(concertSchedules);
 
         // When
         GetConcertSchedulesNotSoldOut.Input input = new GetConcertSchedulesNotSoldOut.Input(concertId);
@@ -101,18 +101,18 @@ public class GetConcertSchedulesNotSoldOutUnitTest {
 
         GetConcertSchedulesNotSoldOut.Output.Item firstSchedule = scheduleItems.get(0);
         assertEquals(1L, firstSchedule.id());
-        assertEquals(false, firstSchedule.isSold());
+        assertEquals(false, firstSchedule.isSoldOut());
         assertEquals(100, firstSchedule.totalSeat());
         assertEquals(50, firstSchedule.availableSeat());
 
         GetConcertSchedulesNotSoldOut.Output.Item secondSchedule = scheduleItems.get(1);
         assertEquals(2L, secondSchedule.id());
-        assertEquals(false, secondSchedule.isSold());
+        assertEquals(false, secondSchedule.isSoldOut());
         assertEquals(200, secondSchedule.totalSeat());
         assertEquals(100, secondSchedule.availableSeat());
 
         verify(concertRepository, times(1)).findById(concertId);
-        verify(concertScheduleRepository, times(1)).findByConcertIdAndIsSold(concertId, false);
+        verify(concertScheduleRepository, times(1)).findByConcertIdAndIsSoldOut(concertId, false);
     }
 
 }

--- a/src/test/java/com/chaw/app/domain/concert/query/usecase/GetTicketsInEmptyReserveStatusIT.java
+++ b/src/test/java/com/chaw/app/domain/concert/query/usecase/GetTicketsInEmptyReserveStatusIT.java
@@ -49,7 +49,7 @@ public class GetTicketsInEmptyReserveStatusIT {
 
         concertSchedule = ConcertSchedule.builder()
                 .concertId(1L)
-                .isSold(false)
+                .isSoldOut(false)
                 .totalSeat(10)
                 .availableSeat(10)
                 .dateConcert(LocalDateTime.now().plusDays(1))

--- a/src/test/java/com/chaw/app/domain/concert/reserve/usecase/PayTicketIT.java
+++ b/src/test/java/com/chaw/app/domain/concert/reserve/usecase/PayTicketIT.java
@@ -94,7 +94,7 @@ public class PayTicketIT {
         concertRepository.save(concert);
 
         concertSchedule = ConcertSchedule.builder()
-                .concertId(1L)
+                .concertId(concert.getId())
                 .isSold(false)
                 .totalSeat(10)
                 .availableSeat(10)

--- a/src/test/java/com/chaw/app/domain/concert/reserve/usecase/PayTicketIT.java
+++ b/src/test/java/com/chaw/app/domain/concert/reserve/usecase/PayTicketIT.java
@@ -19,10 +19,7 @@ import com.chaw.concert.app.domain.concert.queue.repository.WaitQueueRepository;
 import com.chaw.concert.app.domain.concert.reserve.entity.Payment;
 import com.chaw.concert.app.domain.concert.reserve.entity.Reserve;
 import com.chaw.concert.app.domain.concert.reserve.entity.ReserveStatus;
-import com.chaw.concert.app.domain.concert.reserve.exception.AlreadyPaidReserveException;
-import com.chaw.concert.app.domain.concert.reserve.exception.CanceledReserveException;
-import com.chaw.concert.app.domain.concert.reserve.exception.ExpiredReserveException;
-import com.chaw.concert.app.domain.concert.reserve.exception.TicketNotInStatusReserveException;
+import com.chaw.concert.app.domain.concert.reserve.exception.*;
 import com.chaw.concert.app.domain.concert.reserve.repository.PaymentRepository;
 import com.chaw.concert.app.domain.concert.reserve.repository.ReserveRepository;
 import com.chaw.concert.app.domain.concert.reserve.usecase.PayTicket;
@@ -95,7 +92,7 @@ public class PayTicketIT {
 
         concertSchedule = ConcertSchedule.builder()
                 .concertId(concert.getId())
-                .isSold(false)
+                .isSoldOut(false)
                 .totalSeat(10)
                 .availableSeat(10)
                 .dateConcert(LocalDateTime.now().plusDays(1))
@@ -155,12 +152,28 @@ public class PayTicketIT {
         assertEquals(1000 - 100, output.balance());
 
         assertEquals(9, concertScheduleAfter.getAvailableSeat());
-        assertEquals(false, concertScheduleAfter.getIsSold());
+        assertEquals(false, concertScheduleAfter.getIsSoldOut());
         assertEquals(TicketStatus.PAID, ticketAfter.getStatus());
         assertEquals(ReserveStatus.PAID, reserveAfter.getReserveStatus());
         assertEquals(900, pointAfter.getBalance());
         assertEquals(100, pointHistory.getAmount());
         assertEquals(100, payment.getAmount());
+    }
+
+    @Test
+    void payTicketSuccessSoldOut() {
+        concertSchedule.setAvailableSeat(1);
+        concertScheduleRepository.save(concertSchedule);
+
+        PayTicket.Input input = new PayTicket.Input(userId, concert.getId(), concertSchedule.getId(), ticket.getId());
+        PayTicket.Output output = payTicket.execute(input);
+
+        ConcertSchedule concertScheduleAfter = concertScheduleRepository.findById(concertSchedule.getId());
+
+        assertEquals(true, output.success());
+
+        assertEquals(0, concertScheduleAfter.getAvailableSeat());
+        assertEquals(true, concertScheduleAfter.getIsSoldOut());
     }
 
     @Test
@@ -197,6 +210,16 @@ public class PayTicketIT {
         PayTicket.Input input = new PayTicket.Input(userId, concert.getId(), concertSchedule.getId(), ticket.getId());
 
         assertThrows(CanceledReserveException.class, () -> { payTicket.execute(input); });
+    }
+
+    @Test
+    void validate_AvailableSeatNotExist() {
+        concertSchedule.setAvailableSeat(0);
+        concertScheduleRepository.save(concertSchedule);
+
+        PayTicket.Input input = new PayTicket.Input(userId, concert.getId(), concertSchedule.getId(), ticket.getId());
+
+        assertThrows(AvailableSeatNotExistException.class, () -> { payTicket.execute(input); });
     }
 
     @Test

--- a/src/test/java/com/chaw/app/domain/concert/reserve/usecase/PayTicketIT.java
+++ b/src/test/java/com/chaw/app/domain/concert/reserve/usecase/PayTicketIT.java
@@ -147,7 +147,6 @@ public class PayTicketIT {
         Ticket ticketAfter = ticketRepository.findById(ticket.getId());
         Reserve reserveAfter = reserveRepository.findById(reserve.getId());
         Point pointAfter = pointRepository.findByUserId(userId);
-        WaitQueue waitQueueAfter = waitQueueRepository.findByUserId(userId);
         Payment payment = paymentRepository.findById(output.paymentId());
         PointHistory pointHistory = pointHistoryRepository.findById(payment.getPointHistoryId());
 
@@ -162,7 +161,6 @@ public class PayTicketIT {
         assertEquals(900, pointAfter.getBalance());
         assertEquals(100, pointHistory.getAmount());
         assertEquals(100, payment.getAmount());
-        assertNull(waitQueueAfter);
     }
 
     @Test

--- a/src/test/java/com/chaw/app/domain/concert/reserve/usecase/PayTicketUnitTest.java
+++ b/src/test/java/com/chaw/app/domain/concert/reserve/usecase/PayTicketUnitTest.java
@@ -2,7 +2,6 @@ package com.chaw.app.domain.concert.reserve.usecase;
 
 import com.chaw.concert.app.domain.common.user.entity.Point;
 import com.chaw.concert.app.domain.common.user.entity.PointHistory;
-import com.chaw.concert.app.domain.common.user.exception.NotEnoughBalanceException;
 import com.chaw.concert.app.domain.common.user.repository.PointHistoryRepository;
 import com.chaw.concert.app.domain.common.user.repository.PointRepository;
 import com.chaw.concert.app.domain.concert.query.entity.Concert;
@@ -17,9 +16,11 @@ import com.chaw.concert.app.domain.concert.queue.repository.WaitQueueRepository;
 import com.chaw.concert.app.domain.concert.reserve.entity.Payment;
 import com.chaw.concert.app.domain.concert.reserve.entity.Reserve;
 import com.chaw.concert.app.domain.concert.reserve.entity.ReserveStatus;
+import com.chaw.concert.app.domain.concert.reserve.exception.ExpiredReserveException;
 import com.chaw.concert.app.domain.concert.reserve.repository.PaymentRepository;
 import com.chaw.concert.app.domain.concert.reserve.repository.ReserveRepository;
 import com.chaw.concert.app.domain.concert.reserve.usecase.PayTicket;
+import com.chaw.concert.app.domain.concert.reserve.validation.ReserveValidation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -59,6 +60,9 @@ class PayTicketUnitTest {
 
     @Mock
     private PaymentRepository paymentRepository;
+
+    @Mock
+    private ReserveValidation reserveValidation;
 
     @InjectMocks
     private PayTicket payTicket;
@@ -120,6 +124,8 @@ class PayTicketUnitTest {
         when(concertScheduleRepository.findByIdWithLock(ticket.getConcertScheduleId())).thenReturn(concertSchedule);
         when(reserveRepository.findByUserIdAndTicketIdOrderByIdDescLimit(userId, ticketId, 1)).thenReturn(reserve);
         when(waitQueueRepository.findByUserId(userId)).thenReturn(waitQueue);
+        doNothing().when(reserveValidation).validateConcertDetails(concert, concertSchedule, ticket);
+        doNothing().when(reserveValidation).validatePayTicketDetails(waitQueue, point, reserve, ticket);
 
         PayTicket.Input input = new PayTicket.Input(userId, 1L, 1L, ticketId);
 
@@ -128,6 +134,9 @@ class PayTicketUnitTest {
 
         // then
         assertEquals(500, output.balance()); // 남은 포인트 확인
+
+        verify(reserveValidation, times(1)).validateConcertDetails(concert, concertSchedule, ticket);
+        verify(reserveValidation, times(1)).validatePayTicketDetails(waitQueue, point, reserve, ticket);
 
         verify(concertScheduleRepository).save(any(ConcertSchedule.class));
         verify(ticketRepository).save(any(Ticket.class));
@@ -139,59 +148,73 @@ class PayTicketUnitTest {
     }
 
     @Test
-    public void testNotEnoughBalance() {
-        // given
+    void testHandleExpiredReserve_Expired() {
+        // Given
+        Ticket ticket = Ticket.builder().id(1L).status(TicketStatus.RESERVE).build();
+        Reserve reserve = Reserve.builder().amount(500).createdAt(LocalDateTime.now().minusMinutes(60)).reserveStatus(ReserveStatus.RESERVE).build(); // 만료된 상태
+        WaitQueue waitQueue = new WaitQueue();
+
+        // Mocking
+        when(ticketRepository.save(ticket)).thenReturn(ticket);
+        when(reserveRepository.save(reserve)).thenReturn(reserve);
+        doNothing().when(waitQueueRepository).delete(waitQueue);
+
+        // When / Then
+        assertThrows(ExpiredReserveException.class, () -> {
+            payTicket.handleExpiredReserve(ticket, reserve, waitQueue);
+        });
+
+        // Verify
+        verify(ticketRepository, times(1)).save(ticket);
+        verify(reserveRepository, times(1)).save(reserve);
+        verify(waitQueueRepository, times(1)).delete(waitQueue);
+    }
+
+    @Test
+    void testHandleExpiredReserve_NotExpired() {
+        // Given
+        Ticket ticket = Ticket.builder().id(1L).status(TicketStatus.RESERVE).build();
+        Reserve reserve = Reserve.builder().amount(500).createdAt(LocalDateTime.now()).reserveStatus(ReserveStatus.RESERVE).build(); // 만료되지 않은 상태
+        WaitQueue waitQueue = new WaitQueue();
+
+        // When
+        payTicket.handleExpiredReserve(ticket, reserve, waitQueue);
+
+        // Verify (아무 작업도 발생하지 않음)
+        verify(ticketRepository, never()).save(any());
+        verify(reserveRepository, never()).save(any());
+        verify(waitQueueRepository, never()).delete(any());
+    }
+
+    @Test
+    void testExecute_ExpiredReserve() {
+        // Given
         Long userId = 1L;
+        Long concertId = 1L;
         Long ticketId = 1L;
 
-        Point point = Point.builder()
-                .id(1L)
-                .userId(userId)
-                .balance(400) // 잔액 부족
-                .build();
+        Point point = Point.builder().balance(1000).build();
+        Concert concert = Concert.builder().id(concertId).build();
+        Ticket ticket = Ticket.builder().id(ticketId).concertScheduleId(1L).status(TicketStatus.RESERVE).build();
+        ConcertSchedule concertSchedule = ConcertSchedule.builder().id(1L).availableSeat(10).build();
+        Reserve reserve = Reserve.builder().amount(500).createdAt(LocalDateTime.now().minusMinutes(60)).reserveStatus(ReserveStatus.RESERVE).build(); // 만료된 상태
+        WaitQueue waitQueue = new WaitQueue();
 
-        Ticket ticket = Ticket.builder()
-                .id(ticketId)
-                .status(TicketStatus.RESERVE)
-                .concertScheduleId(1L)
-                .build();
-
-        Concert concert = Concert.builder()
-                .id(1L)
-                .name("concert")
-                .build();
-
-        ConcertSchedule concertSchedule = ConcertSchedule.builder()
-                .id(1L)
-                .availableSeat(10)
-                .build();
-
-        Reserve reserve = Reserve.builder()
-                .id(1L)
-                .userId(userId)
-                .ticketId(ticketId)
-                .amount(500)
-                .reserveStatus(ReserveStatus.RESERVE)
-                .createdAt(LocalDateTime.now())
-                .build();
-
-        WaitQueue waitQueue = WaitQueue.builder()
-                .id(1L)
-                .userId(userId)
-                .build();
-
+        // Mocking
         when(pointRepository.findByUserIdWithLock(userId)).thenReturn(point);
+        when(concertRepository.findById(concertId)).thenReturn(concert);
         when(ticketRepository.findById(ticketId)).thenReturn(ticket);
-        when(concertRepository.findById(ticket.getConcertScheduleId())).thenReturn(concert);
-        when(concertScheduleRepository.findByIdWithLock(ticket.getConcertScheduleId())).thenReturn(concertSchedule);
+        when(concertScheduleRepository.findByIdWithLock(1L)).thenReturn(concertSchedule);
         when(reserveRepository.findByUserIdAndTicketIdOrderByIdDescLimit(userId, ticketId, 1)).thenReturn(reserve);
         when(waitQueueRepository.findByUserId(userId)).thenReturn(waitQueue);
 
-        PayTicket.Input input = new PayTicket.Input(userId, 1L, 1L, ticketId);
+        // When / Then
+        PayTicket.Input input = new PayTicket.Input(userId, concertId, 1L, ticketId);
+        assertThrows(ExpiredReserveException.class, () -> payTicket.execute(input));
 
-        // when & then
-        assertThrows(NotEnoughBalanceException.class, () -> payTicket.execute(input));
-
-        verify(waitQueueRepository, never()).delete(any()); // 잔액 부족 시 대기열 삭제되지 않음
+        // Verify
+        verify(ticketRepository, times(1)).save(ticket);
+        verify(reserveRepository, times(1)).save(reserve);
+        verify(waitQueueRepository, times(1)).delete(waitQueue);
     }
 }

--- a/src/test/java/com/chaw/app/domain/concert/reserve/usecase/RequestReserveConcurrencyTest.java
+++ b/src/test/java/com/chaw/app/domain/concert/reserve/usecase/RequestReserveConcurrencyTest.java
@@ -62,7 +62,7 @@ public class RequestReserveConcurrencyTest {
 
         concertSchedule = ConcertSchedule.builder()
                 .concertId(concert.getId())
-                .isSold(false)
+                .isSoldOut(false)
                 .totalSeat(10)
                 .availableSeat(10)
                 .dateConcert(LocalDateTime.now().plusDays(1))

--- a/src/test/java/com/chaw/app/domain/concert/reserve/usecase/RequestReserveConcurrencyTest.java
+++ b/src/test/java/com/chaw/app/domain/concert/reserve/usecase/RequestReserveConcurrencyTest.java
@@ -61,7 +61,7 @@ public class RequestReserveConcurrencyTest {
         concertRepository.save(concert);
 
         concertSchedule = ConcertSchedule.builder()
-                .concertId(1L)
+                .concertId(concert.getId())
                 .isSold(false)
                 .totalSeat(10)
                 .availableSeat(10)
@@ -69,9 +69,11 @@ public class RequestReserveConcurrencyTest {
                 .build();
         concertScheduleRepository.save(concertSchedule);
 
-        ticket = new Ticket();
-        ticket.setStatus(TicketStatus.EMPTY);
-        ticket = ticketRepository.save(ticket);
+        ticket = Ticket.builder()
+                .concertScheduleId(concertSchedule.getId())
+                .status(TicketStatus.EMPTY)
+                .build();
+        ticketRepository.save(ticket);
     }
 
     @AfterEach

--- a/src/test/java/com/chaw/app/domain/concert/reserve/usecase/RequestReserveIT.java
+++ b/src/test/java/com/chaw/app/domain/concert/reserve/usecase/RequestReserveIT.java
@@ -58,7 +58,7 @@ public class RequestReserveIT {
 
         concertSchedule = ConcertSchedule.builder()
                 .concertId(concert.getId())
-                .isSold(false)
+                .isSoldOut(false)
                 .totalSeat(10)
                 .availableSeat(10)
                 .dateConcert(LocalDateTime.now().plusDays(1))

--- a/src/test/java/com/chaw/app/domain/concert/reserve/usecase/RequestReserveIT.java
+++ b/src/test/java/com/chaw/app/domain/concert/reserve/usecase/RequestReserveIT.java
@@ -22,7 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest(classes = ConcertApplication.class)
 @ExtendWith(SpringExtension.class)
@@ -56,7 +57,7 @@ public class RequestReserveIT {
         concertRepository.save(concert);
 
         concertSchedule = ConcertSchedule.builder()
-                .concertId(1L)
+                .concertId(concert.getId())
                 .isSold(false)
                 .totalSeat(10)
                 .availableSeat(10)
@@ -65,6 +66,7 @@ public class RequestReserveIT {
         concertScheduleRepository.save(concertSchedule);
 
         ticket = Ticket.builder()
+                .concertScheduleId(concertSchedule.getId())
                 .status(TicketStatus.EMPTY)
                 .price(100)
                 .build();

--- a/src/test/java/com/chaw/app/domain/concert/reserve/usecase/RequestReserveUnitTest.java
+++ b/src/test/java/com/chaw/app/domain/concert/reserve/usecase/RequestReserveUnitTest.java
@@ -4,21 +4,21 @@ import com.chaw.concert.app.domain.concert.query.entity.Concert;
 import com.chaw.concert.app.domain.concert.query.entity.ConcertSchedule;
 import com.chaw.concert.app.domain.concert.query.entity.Ticket;
 import com.chaw.concert.app.domain.concert.query.entity.TicketStatus;
-import com.chaw.concert.app.domain.concert.query.exception.TicketAlreadyReservedException;
-import com.chaw.concert.app.domain.concert.query.exception.TicketNotFoundException;
 import com.chaw.concert.app.domain.concert.query.repository.ConcertRepository;
 import com.chaw.concert.app.domain.concert.query.repository.ConcertScheduleRepository;
 import com.chaw.concert.app.domain.concert.query.repository.TicketRepository;
 import com.chaw.concert.app.domain.concert.reserve.entity.Reserve;
 import com.chaw.concert.app.domain.concert.reserve.repository.ReserveRepository;
 import com.chaw.concert.app.domain.concert.reserve.usecase.RequestReserve;
+import com.chaw.concert.app.domain.concert.reserve.validation.ReserveValidation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
 
 public class RequestReserveUnitTest {
@@ -35,70 +35,15 @@ public class RequestReserveUnitTest {
     @Mock
     private ReserveRepository reserveRepository;
 
+    @Mock
+    private ReserveValidation reserveValidation;
+
     @InjectMocks
     private RequestReserve requestReserve;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-    }
-
-    @Test
-    void testExecute_TicketNotFound() {
-        // Given
-        Long ticketId = 1L;
-        Long userId = 1L;
-
-        Concert concert = Concert.builder()
-                .id(1L)
-                .name("concert")
-                .build();
-
-        ConcertSchedule concertSchedule = ConcertSchedule.builder()
-                .id(1L)
-                .availableSeat(10)
-                .build();
-
-        when(concertRepository.findById(1L)).thenReturn(concert);
-        when(concertScheduleRepository.findById(1L)).thenReturn(concertSchedule);
-        when(ticketRepository.findByIdWithLock(ticketId)).thenReturn(null);
-
-        // When / Then
-        RequestReserve.Input input = new RequestReserve.Input(userId, 1L, 1L, ticketId);
-        assertThrows(TicketNotFoundException.class, () -> requestReserve.execute(input));
-
-        verify(ticketRepository, times(1)).findByIdWithLock(ticketId);
-        verify(reserveRepository, never()).save(any());
-    }
-
-    @Test
-    void testExecute_TicketAlreadyReserved() {
-        // Given
-        Long ticketId = 1L;
-        Long userId = 1L;
-
-        Concert concert = Concert.builder()
-                .id(1L)
-                .name("concert")
-                .build();
-
-        ConcertSchedule concertSchedule = ConcertSchedule.builder()
-                .id(1L)
-                .availableSeat(10)
-                .build();
-
-        Ticket ticket = Ticket.builder().id(ticketId).status(TicketStatus.RESERVE).build();
-
-        when(concertRepository.findById(1L)).thenReturn(concert);
-        when(concertScheduleRepository.findById(1L)).thenReturn(concertSchedule);
-        when(ticketRepository.findByIdWithLock(ticketId)).thenReturn(ticket);
-
-        // When / Then
-        RequestReserve.Input input = new RequestReserve.Input(userId, 1L, 1L, ticketId);
-        assertThrows(TicketAlreadyReservedException.class, () -> requestReserve.execute(input));
-
-        verify(ticketRepository, times(1)).findByIdWithLock(ticketId);
-        verify(reserveRepository, never()).save(any());
     }
 
     @Test
@@ -137,6 +82,8 @@ public class RequestReserveUnitTest {
 
         verify(ticketRepository, times(1)).findByIdWithLock(ticketId);
         verify(ticketRepository, times(1)).save(ticket);
+        verify(reserveValidation, times(1)).validateConcertDetails(concert, concertSchedule, ticket);
+        verify(reserveValidation, times(1)).validateReserveDetails(ticket);
         verify(reserveRepository, times(1)).save(any(Reserve.class));
     }
 }

--- a/src/test/java/com/chaw/app/domain/concert/reserve/validation/ReserveValidationUnitTest.java
+++ b/src/test/java/com/chaw/app/domain/concert/reserve/validation/ReserveValidationUnitTest.java
@@ -11,7 +11,6 @@ import com.chaw.concert.app.domain.concert.query.exception.ConcertNotFoundExcept
 import com.chaw.concert.app.domain.concert.query.exception.ConcertScheduleNotFoundException;
 import com.chaw.concert.app.domain.concert.query.exception.TicketAlreadyReservedException;
 import com.chaw.concert.app.domain.concert.query.exception.TicketNotFoundException;
-import com.chaw.concert.app.domain.concert.queue.entity.WaitQueue;
 import com.chaw.concert.app.domain.concert.reserve.entity.Reserve;
 import com.chaw.concert.app.domain.concert.reserve.entity.ReserveStatus;
 import com.chaw.concert.app.domain.concert.reserve.exception.*;
@@ -104,19 +103,17 @@ class ReserveValidationUnitTest {
 
     @Test
     void validatePayTicketDetails_PointNotFoundException() {
-        WaitQueue waitQueue = new WaitQueue();
         Point point = null;  // 포인트 없음
         Reserve reserve = new Reserve();
         Ticket ticket = new Ticket();
 
         assertThrows(PointNotFoundException.class, () -> {
-            reserveValidation.validatePayTicketDetails(waitQueue, point, reserve, ticket);
+            reserveValidation.validatePayTicketDetails(point, reserve, ticket);
         });
     }
 
     @Test
     void validatePayTicketDetails_NotEnoughBalanceException() {
-        WaitQueue waitQueue = new WaitQueue();
         Point point = new Point();
         point.setBalance(50);  // 잔액 부족
         Reserve reserve = new Reserve();
@@ -124,13 +121,12 @@ class ReserveValidationUnitTest {
         Ticket ticket = new Ticket();
 
         assertThrows(NotEnoughBalanceException.class, () -> {
-            reserveValidation.validatePayTicketDetails(waitQueue, point, reserve, ticket);
+            reserveValidation.validatePayTicketDetails(point, reserve, ticket);
         });
     }
 
     @Test
     void validatePayTicketDetails_TicketNotInStatusReserveException() {
-        WaitQueue waitQueue = new WaitQueue();
         Point point = new Point();
         point.setBalance(100);
         Reserve reserve = new Reserve();
@@ -139,13 +135,12 @@ class ReserveValidationUnitTest {
         ticket.setStatus(TicketStatus.PAID);  // 티켓이 RESERVE 상태가 아님
 
         assertThrows(TicketNotInStatusReserveException.class, () -> {
-            reserveValidation.validatePayTicketDetails(waitQueue, point, reserve, ticket);
+            reserveValidation.validatePayTicketDetails(point, reserve, ticket);
         });
     }
 
     @Test
     void validatePayTicketDetails_AlreadyPaidReserveException() {
-        WaitQueue waitQueue = new WaitQueue();
         Point point = new Point();
         point.setBalance(100);
         Reserve reserve = new Reserve();
@@ -155,13 +150,12 @@ class ReserveValidationUnitTest {
         ticket.setStatus(TicketStatus.RESERVE);
 
         assertThrows(AlreadyPaidReserveException.class, () -> {
-            reserveValidation.validatePayTicketDetails(waitQueue, point, reserve, ticket);
+            reserveValidation.validatePayTicketDetails(point, reserve, ticket);
         });
     }
 
     @Test
     void validatePayTicketDetails_CanceledReserveException() {
-        WaitQueue waitQueue = new WaitQueue();
         Point point = new Point();
         point.setBalance(100);
         Reserve reserve = new Reserve();
@@ -171,7 +165,7 @@ class ReserveValidationUnitTest {
         ticket.setStatus(TicketStatus.RESERVE);
 
         assertThrows(CanceledReserveException.class, () -> {
-            reserveValidation.validatePayTicketDetails(waitQueue, point, reserve, ticket);
+            reserveValidation.validatePayTicketDetails(point, reserve, ticket);
         });
     }
 }

--- a/src/test/java/com/chaw/app/domain/concert/reserve/validation/ReserveValidationUnitTest.java
+++ b/src/test/java/com/chaw/app/domain/concert/reserve/validation/ReserveValidationUnitTest.java
@@ -1,0 +1,177 @@
+package com.chaw.app.domain.concert.reserve.validation;
+
+import com.chaw.concert.app.domain.common.user.entity.Point;
+import com.chaw.concert.app.domain.common.user.exception.NotEnoughBalanceException;
+import com.chaw.concert.app.domain.common.user.exception.PointNotFoundException;
+import com.chaw.concert.app.domain.concert.query.entity.Concert;
+import com.chaw.concert.app.domain.concert.query.entity.ConcertSchedule;
+import com.chaw.concert.app.domain.concert.query.entity.Ticket;
+import com.chaw.concert.app.domain.concert.query.entity.TicketStatus;
+import com.chaw.concert.app.domain.concert.query.exception.ConcertNotFoundException;
+import com.chaw.concert.app.domain.concert.query.exception.ConcertScheduleNotFoundException;
+import com.chaw.concert.app.domain.concert.query.exception.TicketAlreadyReservedException;
+import com.chaw.concert.app.domain.concert.query.exception.TicketNotFoundException;
+import com.chaw.concert.app.domain.concert.queue.entity.WaitQueue;
+import com.chaw.concert.app.domain.concert.reserve.entity.Reserve;
+import com.chaw.concert.app.domain.concert.reserve.entity.ReserveStatus;
+import com.chaw.concert.app.domain.concert.reserve.exception.*;
+import com.chaw.concert.app.domain.concert.reserve.validation.ReserveValidation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ReserveValidationUnitTest {
+
+    private ReserveValidation reserveValidation;
+
+    @BeforeEach
+    void setUp() {
+        reserveValidation = new ReserveValidation();
+    }
+
+    @Test
+    void validateConcertDetails_ConcertNotFoundException() {
+        Concert concert = null;
+        ConcertSchedule concertSchedule = new ConcertSchedule();
+        Ticket ticket = new Ticket();
+
+        assertThrows(ConcertNotFoundException.class, () -> {
+            reserveValidation.validateConcertDetails(concert, concertSchedule, ticket);
+        });
+    }
+
+    @Test
+    void validateConcertDetails_ConcertScheduleNotFoundException() {
+        Concert concert = new Concert();
+        ConcertSchedule concertSchedule = null;
+        Ticket ticket = new Ticket();
+
+        assertThrows(ConcertScheduleNotFoundException.class, () -> {
+            reserveValidation.validateConcertDetails(concert, concertSchedule, ticket);
+        });
+    }
+
+    @Test
+    void validateConcertDetails_TicketNotFoundException() {
+        Concert concert = new Concert();
+        ConcertSchedule concertSchedule = new ConcertSchedule();
+        Ticket ticket = null;
+
+        assertThrows(TicketNotFoundException.class, () -> {
+            reserveValidation.validateConcertDetails(concert, concertSchedule, ticket);
+        });
+    }
+
+    @Test
+    void validateConcertDetails_IllegalConcertAndScheduleException() {
+        Concert concert = new Concert();
+        concert.setId(1L);
+        ConcertSchedule concertSchedule = new ConcertSchedule();
+        concertSchedule.setConcertId(2L);
+        Ticket ticket = new Ticket();
+        ticket.setConcertScheduleId(2L);
+
+        assertThrows(IllegalConcertAndScheduleException.class, () -> {
+            reserveValidation.validateConcertDetails(concert, concertSchedule, ticket);
+        });
+    }
+
+    @Test
+    void validateConcertDetails_IllegalScheduleAndTicketException() {
+        Concert concert = new Concert();
+        concert.setId(1L);
+        ConcertSchedule concertSchedule = new ConcertSchedule();
+        concertSchedule.setId(1L);
+        concertSchedule.setConcertId(1L);
+        Ticket ticket = new Ticket();
+        ticket.setConcertScheduleId(2L);
+
+        assertThrows(IllegalScheduleAndTicketException.class, () -> {
+            reserveValidation.validateConcertDetails(concert, concertSchedule, ticket);
+        });
+    }
+
+    @Test
+    void validateReserveDetails_TicketAlreadyReservedException() {
+        Ticket ticket = new Ticket();
+        ticket.setStatus(TicketStatus.PAID);  // TicketStatus가 EMPTY가 아님
+
+        assertThrows(TicketAlreadyReservedException.class, () -> {
+            reserveValidation.validateReserveDetails(ticket);
+        });
+    }
+
+    @Test
+    void validatePayTicketDetails_PointNotFoundException() {
+        WaitQueue waitQueue = new WaitQueue();
+        Point point = null;  // 포인트 없음
+        Reserve reserve = new Reserve();
+        Ticket ticket = new Ticket();
+
+        assertThrows(PointNotFoundException.class, () -> {
+            reserveValidation.validatePayTicketDetails(waitQueue, point, reserve, ticket);
+        });
+    }
+
+    @Test
+    void validatePayTicketDetails_NotEnoughBalanceException() {
+        WaitQueue waitQueue = new WaitQueue();
+        Point point = new Point();
+        point.setBalance(50);  // 잔액 부족
+        Reserve reserve = new Reserve();
+        reserve.setAmount(100);  // 필요한 금액
+        Ticket ticket = new Ticket();
+
+        assertThrows(NotEnoughBalanceException.class, () -> {
+            reserveValidation.validatePayTicketDetails(waitQueue, point, reserve, ticket);
+        });
+    }
+
+    @Test
+    void validatePayTicketDetails_TicketNotInStatusReserveException() {
+        WaitQueue waitQueue = new WaitQueue();
+        Point point = new Point();
+        point.setBalance(100);
+        Reserve reserve = new Reserve();
+        reserve.setAmount(50);
+        Ticket ticket = new Ticket();
+        ticket.setStatus(TicketStatus.PAID);  // 티켓이 RESERVE 상태가 아님
+
+        assertThrows(TicketNotInStatusReserveException.class, () -> {
+            reserveValidation.validatePayTicketDetails(waitQueue, point, reserve, ticket);
+        });
+    }
+
+    @Test
+    void validatePayTicketDetails_AlreadyPaidReserveException() {
+        WaitQueue waitQueue = new WaitQueue();
+        Point point = new Point();
+        point.setBalance(100);
+        Reserve reserve = new Reserve();
+        reserve.setAmount(50);
+        reserve.setReserveStatus(ReserveStatus.PAID);  // 예약이 이미 결제 완료됨
+        Ticket ticket = new Ticket();
+        ticket.setStatus(TicketStatus.RESERVE);
+
+        assertThrows(AlreadyPaidReserveException.class, () -> {
+            reserveValidation.validatePayTicketDetails(waitQueue, point, reserve, ticket);
+        });
+    }
+
+    @Test
+    void validatePayTicketDetails_CanceledReserveException() {
+        WaitQueue waitQueue = new WaitQueue();
+        Point point = new Point();
+        point.setBalance(100);
+        Reserve reserve = new Reserve();
+        reserve.setAmount(50);
+        reserve.setReserveStatus(ReserveStatus.CANCEL);  // 예약이 취소됨
+        Ticket ticket = new Ticket();
+        ticket.setStatus(TicketStatus.RESERVE);
+
+        assertThrows(CanceledReserveException.class, () -> {
+            reserveValidation.validatePayTicketDetails(waitQueue, point, reserve, ticket);
+        });
+    }
+}


### PR DESCRIPTION
## 작업내용
- [x] 비즈니스 Usecase 개발
  - [x] [대기열 발급 & 대기순번 조회](https://github.com/chawchaw/concert/blob/feature/step08/src/main/java/com/chaw/concert/app/domain/concert/queue/usecase/EnterWaitQueue.java)
  - [x] [콘서트 조회](https://github.com/chawchaw/concert/blob/feature/step08/src/main/java/com/chaw/concert/app/domain/concert/query/usecase/GetConcerts.java)
  - [x] [일정 조회](https://github.com/chawchaw/concert/blob/feature/step08/src/main/java/com/chaw/concert/app/domain/concert/query/usecase/GetConcertSchedulesNotSoldOut.java)
  - [x] [좌석(티켓) 조회](https://github.com/chawchaw/concert/blob/feature/step08/src/main/java/com/chaw/concert/app/domain/concert/query/usecase/GetTicketsInEmptyStatus.java)
  - [x] [예약](https://github.com/chawchaw/concert/blob/feature/step08/src/main/java/com/chaw/concert/app/domain/concert/reserve/usecase/RequestReserve.java)
  - [x] [결제](https://github.com/chawchaw/concert/blob/feature/step08/src/main/java/com/chaw/concert/app/domain/concert/reserve/usecase/PayTicket.java)
  - [x] [포인트 충전](https://github.com/chawchaw/concert/blob/feature/step08/src/main/java/com/chaw/concert/app/domain/common/user/usecase/ChargePoint.java)
  - [x] [포인트 조회](https://github.com/chawchaw/concert/blob/feature/step08/src/main/java/com/chaw/concert/app/domain/common/user/usecase/GetPoint.java)
  - [x] [대기열통과](https://github.com/chawchaw/concert/blob/feature/step08/src/main/java/com/chaw/concert/app/domain/concert/queue/scheduler/PassWaitQueue.java) - [스케줄러](https://github.com/chawchaw/concert/blob/feature/step08/src/main/java/com/chaw/concert/app/presenter/scheduler/concert/QueueScheduler.java)
  - [x] [예약만료](https://github.com/chawchaw/concert/blob/feature/step08/src/main/java/com/chaw/concert/app/domain/concert/reserve/scheduler/ExpireReserve.java) - [스케줄러](https://github.com/chawchaw/concert/blob/feature/step08/src/main/java/com/chaw/concert/app/presenter/scheduler/concert/ReserveScheduler.java) 
  - [x] [대기열종료](https://github.com/chawchaw/concert/blob/feature/step08/src/main/java/com/chaw/concert/app/domain/concert/queue/scheduler/ExpireWaitQueue.java) - [스케줄러](https://github.com/chawchaw/concert/blob/feature/step08/src/main/java/com/chaw/concert/app/presenter/scheduler/concert/QueueScheduler.java)
- [x] 통합 테스트
  - [x] [대기열](https://github.com/chawchaw/concert/tree/feature/step08/src/test/java/com/chaw/app/domain/concert/query/usecase)
  - [x] [조회](https://github.com/chawchaw/concert/tree/feature/step08/src/test/java/com/chaw/app/domain/concert/query/usecase)
  - [x] [예약,결제](https://github.com/chawchaw/concert/tree/feature/step08/src/test/java/com/chaw/app/domain/concert/reserve)
  - [x] [포인트](https://github.com/chawchaw/concert/tree/feature/step08/src/test/java/com/chaw/app/domain/user/usecase)
  - [x] [E2E 테스트](https://github.com/chawchaw/concert/blob/feature/step08/src/test/java/com/chaw/app/domain/concert/e2e/ConcertE2E.java#L139)

- usecase 레이어
  - 도메인 레이어 하위에 usecase 레이어를 만들었습니다.
  - 비즈니스 로직 구현이 usecase 에서 모두 구현 되다보니
  - facade 레이어가 없어서 과제에서 얘기하는 유즈케이스가 usecase 레이어로 된 것 같습니다.
  (구현은 Step07 에서 이미 완료하여 이번 PR의 Files changed 에 없습니다. 위의 작업내용 링크로 확인할 수 있습니다)

## 리뷰 포인트
- [E2E 테스트](https://github.com/chawchaw/concert/blob/feature/step08/src/test/java/com/chaw/app/domain/concert/e2e/ConcertE2E.java)
  - Swagger 로 직접 테스트 할때 기초 데이터 생성에 대해
  SQL 쿼리를 만드는 방법과
  테스트 코드를 활용하는 방법중
  어떤것이 좋을까요?
